### PR TITLE
Added directory creation step to instructions in README.md

### DIFF
--- a/DisplayNixie/README.md
+++ b/DisplayNixie/README.md
@@ -27,8 +27,9 @@ A simple program that show the current system time at the Nixie tubes.
   2.1) or CLI way "sudo raspi-config": https://photos.app.goo.gl/wfoPd8CNLSlJ0bF83
 
   3) cd into .../DisplayNixie/src
-  4) Run 'make'
-  5) Binary will be placed at .../DisplayNixie/bin/DisplayNixie, a la:
+  4) mkdir ../bin (make will fail if bin folder does not exist)
+  5) Run 'make'
+  6) Binary will be placed at .../DisplayNixie/bin/DisplayNixie, a la:
 	/nixie/NixieClockRaspberryPi-shaner/DisplayNixie/bin/DisplayNixie
 
 ### Сommand line options (shaner mods):


### PR DESCRIPTION
First off thanks, these are great additions, was a little surprised that it wasn't using the system time to take advantage of NTP to begin with.

Just ran into a small issue was that after cloning the repository `make` failed since the `.../DisplayNixie/bin`folder didn't exist.

```
pi@nixie:~/NixieClockRaspberryPi/DisplayNixie/src$ make
Building target: DisplayNixie
Invoking: Cross G++ Linker
g++  -o "../bin/DisplayNixie"  DisplayNixie.o   -lwiringPi
/usr/bin/ld: cannot open output file ../bin/DisplayNixie: No such file or directory
collect2: error: ld returned 1 exit status
```

So I added a step to the instructions in `README.md` to create the bin directory.